### PR TITLE
Removed 'inline' modifier

### DIFF
--- a/pqlib/PQ.c
+++ b/pqlib/PQ.c
@@ -406,7 +406,7 @@ pq_data_t pq_dequeue(pq_t queue, pq_status_t *status) {
 // Returns the number of entries stored in <queue>,  returns  zero  if NULL is
 // passed in for <queue>.
 
-inline cardinal pq_number_of_entries(pq_t queue) {
+cardinal pq_number_of_entries(pq_t queue) {
 
     pq_s *this_queue = (pq_s *) queue;
     

--- a/pqlib/PQ.h
+++ b/pqlib/PQ.h
@@ -217,7 +217,7 @@ pq_data_t pq_dequeue(pq_t queue, pq_status_t *status);
 // Returns the number of entries stored in <queue>,  returns  zero  if NULL is
 // passed in for <queue>.
 
-inline pq_counter_t pq_number_of_entries(pq_t queue);
+pq_counter_t pq_number_of_entries(pq_t queue);
 
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Removed 'inline' modifier from pq_number_of_entries function, so GCC does not argue at "inline function 'pq_number_of_entries' declared but never defined" when compiling files using this library.